### PR TITLE
Add chat button to bottom tab nav

### DIFF
--- a/features/chat/constants.ts
+++ b/features/chat/constants.ts
@@ -1,0 +1,2 @@
+export const discordOnWebsiteUrl =
+  'https://listen.dublindigitalradio.com/discord';

--- a/features/chat/useFetchDiscordInviteUrl.ts
+++ b/features/chat/useFetchDiscordInviteUrl.ts
@@ -1,0 +1,26 @@
+import {useEffect, useState} from 'react';
+
+import {StrapiEntryResponse} from '../../utils/strapi';
+
+const discordInviteApiUrl = 'https://ddr-cms.fly.dev/api/strapi-invite-link';
+
+export function useFetchDiscordInviteUrl() {
+  const [discordInviteUrl, setDiscordInviteUrl] = useState<string>();
+
+  useEffect(() => {
+    fetch(discordInviteApiUrl)
+      .then(response => response.json())
+      .then(response => response as StrapiEntryResponse<{URL: string}>)
+      .then(response => setDiscordInviteUrl(response.data.attributes.URL));
+  }, []);
+
+  const discordInviteDeepLinkUri = discordInviteUrl?.replace(
+    'https://',
+    'discord://',
+  );
+
+  return {
+    discordInviteUrl,
+    discordInviteDeepLinkUri,
+  };
+}

--- a/ios/DDRMobile/Info.plist
+++ b/ios/DDRMobile/Info.plist
@@ -26,6 +26,10 @@
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>discord</string>
+	</array>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSExceptionDomains</key>

--- a/screens/ChatScreen.tsx
+++ b/screens/ChatScreen.tsx
@@ -1,0 +1,95 @@
+import React, {useMemo} from 'react';
+import {
+  Linking,
+  Platform,
+  Pressable,
+  SafeAreaView,
+  StyleSheet,
+  View,
+} from 'react-native';
+import {useTheme} from '@react-navigation/native';
+import Icon from 'react-native-vector-icons/AntDesign';
+
+import Text from '../components/Text';
+import {discordOnWebsiteUrl} from '../features/chat/constants';
+import {useFetchDiscordInviteUrl} from '../features/chat/useFetchDiscordInviteUrl';
+
+const appDownloadUrl =
+  Platform.OS === 'ios'
+    ? 'https://apps.apple.com/us/app/discord-chat-for-games/id985746746'
+    : 'https://play.google.com/store/apps/details?id=com.discord';
+
+export default function ChatScreen() {
+  const {colors} = useTheme();
+  const {discordInviteUrl, discordInviteDeepLinkUri} =
+    useFetchDiscordInviteUrl();
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        rootView: {
+          flex: 1,
+          alignItems: 'center',
+          justifyContent: 'center',
+        },
+        horizontalContainer: {
+          flexDirection: 'row',
+          alignItems: 'center',
+        },
+        text: {
+          fontSize: 24,
+        },
+        link: {
+          color: colors.primary,
+        },
+        wayToJoinContainer: {
+          width: '90%',
+          marginBottom: 20,
+        },
+      }),
+    [colors.primary],
+  );
+
+  return (
+    <SafeAreaView style={styles.rootView}>
+      {discordInviteUrl && discordInviteDeepLinkUri ? (
+        <>
+          <View style={styles.wayToJoinContainer}>
+            <Text style={styles.text}>Join the ddr chat on Discord</Text>
+            <View style={styles.horizontalContainer}>
+              <Text style={styles.text}>1. </Text>
+              <Pressable onPress={() => Linking.openURL(appDownloadUrl)}>
+                <Text style={[styles.text, styles.link]}>Download Discord</Text>
+              </Pressable>
+            </View>
+            <View style={styles.horizontalContainer}>
+              <Text style={styles.text}>2. </Text>
+              <Pressable
+                onPress={() => {
+                  Linking.canOpenURL(discordInviteDeepLinkUri)
+                    .then(() => Linking.openURL(discordInviteDeepLinkUri))
+                    .catch(() => Linking.openURL(discordInviteUrl));
+                }}>
+                <Text style={[styles.text, styles.link]}>
+                  Accept the invite
+                </Text>
+              </Pressable>
+            </View>
+          </View>
+          <View style={styles.wayToJoinContainer}>
+            <Text style={styles.text}>Or</Text>
+          </View>
+        </>
+      ) : null}
+      <View style={styles.wayToJoinContainer}>
+        <View style={styles.horizontalContainer}>
+          <Text style={styles.text}>Join us on the </Text>
+          <Pressable onPress={() => Linking.openURL(discordOnWebsiteUrl)}>
+            <Text style={[styles.text, styles.link]}>
+              website <Icon name="link" size={20} />
+            </Text>
+          </Pressable>
+        </View>
+      </View>
+    </SafeAreaView>
+  );
+}


### PR DESCRIPTION
# iOS
- User taps on the chat button
  - User doesn't have Discord installed, show screen with instructions to download Discord and accept invite, with link to App Store.
  - User has Discord installed, open invite screen in Discord.

# Android
- User taps on the chat button
  - User doesn't have Discord installed, open invite link in browser, user accepts and goes to Play Store.
  - User has Discord installed, (hopefully) open invite screen in Discord*.

\* "Hopefully" because AFAIK the `discord://` URI scheme doesn't work on Android unlike iOS. We have to rely on the Discord app to handle `https://discord.gg/...`.